### PR TITLE
予約関連ページの改善・拡充

### DIFF
--- a/app/assets/stylesheets/reservations/reservation.css
+++ b/app/assets/stylesheets/reservations/reservation.css
@@ -103,7 +103,7 @@
   padding-left: 20px;
   border-radius: 5px;
 }
-.reservation-page .btn {
+/* .reservation-page .btn {
   display: inline-block;
   height: 50px;
   padding: 0 30px;
@@ -118,7 +118,7 @@
   margin-top: 30px;
   color: #fff;
   background-color: #253141;
-}
+} */
 .reservation-page .back-btn {
   margin-top: 30px;
   margin-left: 30px;
@@ -197,10 +197,10 @@
   color: #FAFAFA;
   text-decoration: none;
 }
-.log-out{
+.sign-out{
   font-size: 14px;
 }
-.log-out a{
+.sign-out a{
   padding: 14px;
   color: #253141;
   text-decoration: none;
@@ -364,6 +364,99 @@
   border-bottom: solid 1px #aaaaaa;
   text-align: center;
   text-align: left;
+}
+
+/********** 予約登録ページ **********/
+.reservation-parent {
+  height: calc(100vh - 100px - 100px);
+  background-color: #fafafa;
+  padding-top: 100px;
+  display: flex;
+  justify-content: center;
+}
+.reservation {
+  margin-left: auto;
+  margin-right: auto;
+}
+.reservation .field {
+  margin-bottom: 10px;
+}
+.reservation .field .field-label {
+  padding: 10px 0;
+  letter-spacing: 1px;
+  font-size: 14px;
+  font-weight: 200;
+}
+.reservation .field .field-label i {
+  font-size: 11px;
+}
+.reservation .field .field-input input {
+  width: 100%;
+  padding: 10px;
+  letter-spacing: 1px;
+}
+.reservation .field-parent {
+  display: flex;
+  justify-content: space-between;
+}
+.reservation .field-child {
+  margin-bottom: 10px;
+  margin-right: 15px;
+}
+.reservation .field-child .field-label {
+  padding: 10px 0;
+  letter-spacing: 1px;
+  font-size: 14px;
+  font-weight: 200;
+}
+.reservation-page .field-child .field-label i {
+  font-size: 11px;
+}
+.reservation .field-child .field-input input {
+  width: 225px;
+  padding: 10px;
+  letter-spacing: 1px;
+}
+.reservation .select-start-time, .year {
+  height: 40px;
+  width: 80px;
+  font-size: 20px;
+  background-color: #f5f5f5;
+  margin-right: 5px;
+  border-radius: 5px;
+}
+.reservation .select-start-time, .month, .day, .hour, .minute {
+  height: 40px;
+  width: 55px;
+  font-size: 20px;
+  background-color: #f5f5f5;
+  margin-left: 15px;
+  margin-right: 5px;
+  border-radius: 5px;
+}
+.reservation .select-box {
+  height: 40px;
+  width: 100%;
+  font-size: 20px;
+  background-color: #f5f5f5;
+  padding-left: 20px;
+  border-radius: 5px;
+}
+.header-button-parent .actions .btn {
+  display: inline-block;
+  margin-top: 24px;
+  margin-left: 40px;
+  padding: 18px 20px;
+  text-align: center;
+  border: solid 1px #253141;
+  border-radius: 5px;
+  font-size: 16px;
+  text-decoration: none;
+}
+.header-button-parent .actions input[type=submit] {
+  float: left;
+  color: #fff;
+  background-color: #253141;
 }
 
 /********** トップページ **********/

--- a/app/assets/stylesheets/reservations/reservation.css
+++ b/app/assets/stylesheets/reservations/reservation.css
@@ -207,20 +207,20 @@
   background-color: white;
   border-radius: 5px;
 }
-.staffs{
+.staffs {
   height: calc(100vh - 100px - 30px);
   background-color: #2f3e51;
   padding: 30px 60px 0;
   /* overflow: scroll; */
 }
-.staff{
+.staff {
   border-radius: 5px;
   border: solid 1px #2f3e51;
   background-color: white;
   text-align: center;
   margin-bottom: 30px;
 }
-.staff a{
+.staff a {
   padding: 20px;
   text-decoration: none;
   color: #2f3e51;
@@ -247,6 +247,7 @@
 }
 .header-button{
   margin-top: 40px;
+  margin-left: 40px;
 }
 .header-button a {
   text-decoration: none;
@@ -255,11 +256,11 @@
   background-color: #253141;
   border-radius: 5px;
 }
-.header-button-destroy{
+.header-button-reverse {
   margin-top: 40px;
-  margin-right: 40px;
+  margin-left: 40px;
 }
-.header-button-destroy a {
+.header-button-reverse a {
   text-decoration: none;
   padding: 20px;
   color: #253141;

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the top controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
                                       keys: [:last_name, :first_name, :last_name_kana, :first_name_kana, :phone_number])
   end
 
-  def after_sign_in_path_for(resource) 
+  def after_sign_in_path_for(_resource)
     staffs_path
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,4 +9,8 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:account_update,
                                       keys: [:last_name, :first_name, :last_name_kana, :first_name_kana, :phone_number])
   end
+
+  def after_sign_in_path_for(resource) 
+    staffs_path
+  end
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -50,7 +50,8 @@ class ReservationsController < ApplicationController
     @reservations = Reservation.where(staff_id: @reservation.staff_id).where(start_time: @search_date.in_time_zone.all_day).where.not(id: @pre_reservation.id)
     return_value = Reservation.check(@reservation, @reservations, @business_hours_end_time)
     if return_value == 0
-      if @pre_reservation.update(start_time: @reservation.start_time, end_time: @reservation.end_time, staff_id: @reservation.staff_id, menu_id: @reservation.menu_id)
+      if @pre_reservation.update(start_time: @reservation.start_time, end_time: @reservation.end_time,
+                                 staff_id: @reservation.staff_id, menu_id: @reservation.menu_id)
         redirect_to reservations_path(id: @reservation.staff.id)
       else
         render :edit
@@ -101,7 +102,8 @@ class ReservationsController < ApplicationController
     @reservation = Reservation.new(reservation_params)
     @menu = Menu.find(@reservation.menu_id)
     @reservation.end_time = @reservation.start_time + @menu.time * 60 * 60
-    @search_date = DateTime.new(@reservation.start_time.year, @reservation.start_time.mon, @reservation.start_time.day, 0, 0, 0,'+09:00')
+    @search_date = DateTime.new(@reservation.start_time.year, @reservation.start_time.mon, @reservation.start_time.day, 0, 0, 0,
+                                '+09:00')
     @business_hours_end_time = DateTime.new(@search_date.year, @search_date.mon, @search_date.day, 18, 0, 0, '+09:00')
   end
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,6 +1,6 @@
 class ReservationsController < ApplicationController
   before_action :authenticate_customer!, except: :index
-  before_action :set_staffs, only: [:index, :show]
+  before_action :set_staffs, only: [:new, :create, :index, :show]
   before_action :set_reservation, only: [:show, :edit, :destroy]
   before_action :move_to_index, only: [:edit]
   before_action :set_end_time, only: [:create, :update]

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -72,9 +72,8 @@ class ReservationsController < ApplicationController
 
   def destroy
     if @reservation.start_time > DateTime.now
-      @pre_reservation = @reservation
       @reservation.destroy
-      redirect_to reservations_path(id: @pre_reservation.staff.id) and return
+      redirect_to staffs_path and return
     else
       redirect_to reservations_path(id: @reservation.staff.id) and return
     end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,6 +1,6 @@
 class ReservationsController < ApplicationController
   before_action :authenticate_customer!, except: :index
-  before_action :set_staffs, only: [:new, :create, :index, :show]
+  before_action :set_staffs, except: :destroy
   before_action :set_reservation, only: [:show, :edit, :destroy]
   before_action :move_to_index, only: [:edit]
   before_action :set_end_time, only: [:create, :update]

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,5 +1,5 @@
 class ReservationsController < ApplicationController
-  before_action :authenticate_customer!
+  before_action :authenticate_customer!, except: :index
   before_action :set_staffs, only: [:index, :show]
   before_action :set_reservation, only: [:show, :edit, :destroy]
   before_action :move_to_index, only: [:edit]

--- a/app/controllers/staffs_controller.rb
+++ b/app/controllers/staffs_controller.rb
@@ -1,5 +1,5 @@
 class StaffsController < ApplicationController
-  before_action :authenticate_customer!
+  before_action :authenticate_customer!, except: :index
 
   def index
     @staffs = Staff.where.not(id: 0)

--- a/app/controllers/staffs_controller.rb
+++ b/app/controllers/staffs_controller.rb
@@ -3,5 +3,6 @@ class StaffsController < ApplicationController
 
   def index
     @staffs = Staff.where.not(id: 0)
+    @reservations = Reservation.where('start_time >= ?', Date.today).order(start_time: 'ASC')
   end
 end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,4 +1,4 @@
-class TopController < ApplicationController  
+class TopController < ApplicationController
   def index
     @staffs = Staff.where.not(id: 0)
   end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,0 +1,5 @@
+class TopController < ApplicationController  
+  def index
+    @staffs = Staff.where.not(id: 0)
+  end
+end

--- a/app/helpers/top_helper.rb
+++ b/app/helpers/top_helper.rb
@@ -1,0 +1,2 @@
+module TopHelper
+end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -16,6 +16,7 @@ class Reservation < ApplicationRecord
   end
 
   def self.check(reservation, reservations, business_hours_end_time)
+    reservation.valid?
     break_flag = 0
     if reservation.start_time < DateTime.now    # 過去
       break_flag = 4

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -31,6 +31,6 @@ class Reservation < ApplicationRecord
         end
       end
     end
-    return break_flag
+    break_flag
   end
 end

--- a/app/views/reservations/_main.html.erb
+++ b/app/views/reservations/_main.html.erb
@@ -5,8 +5,22 @@
     </div>
   </div>
   <div class="right-header">
-    <div class="header-button">
-      <%= link_to "New Reservation", new_reservation_path, method: :get %>
+    <div class="header-button-parent">
+      <div class="header-button-reverse">
+        <%= link_to "Top Page", root_path, method: :get %>
+      </div>
+      <% if customer_signed_in? %>
+      <div class="header-button">
+        <%= link_to "To New Reservation", new_reservation_path, method: :get %>
+      </div>
+      <% else %>
+      <div class="header-button-reverse">
+        <%= link_to "To Sign Up", new_customer_registration_path, method: :get %>
+      </div>
+      <div class="header-button">
+        <%= link_to "To Sign In", new_customer_session_path, method: :get %>
+      </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/reservations/_reservation.html.erb
+++ b/app/views/reservations/_reservation.html.erb
@@ -1,5 +1,5 @@
 <div class="reservation">
-  <% if current_customer.id == reservation.customer.id %>
+  <% if customer_signed_in? && current_customer.id == reservation.customer.id %>
   <tr>
     <td><%= link_to reservation.start_time.strftime('%Y/%m/%d') + '(' + %w(日 月 火 水 木 金 土)[reservation.start_time.wday] + ')', reservation_path(reservation.id) %></td>
     <td><%= link_to reservation.start_time.strftime('%H:%M'), reservation_path(reservation.id) %></td>

--- a/app/views/reservations/_side_bar.html.erb
+++ b/app/views/reservations/_side_bar.html.erb
@@ -4,10 +4,13 @@
           edit_customer_registration_path(current_customer), method: :get, class: "customer-name" %>
   </div>
   <div class="log-out">
-    <%= link_to "Log Out", destroy_customer_session_path, method: :delete %>
+    <%= link_to "Sign Out", destroy_customer_session_path, method: :delete %>
   </div>
 </div>
 <div class="staffs">
+  <div class="staff">
+    <%= link_to 'すべて', staffs_path %>
+  </div>
   <% @staffs.each do |staff| %>
     <div class="staff">
       <%= link_to staff.name, reservations_path(id: staff.id) %>

--- a/app/views/reservations/_side_bar.html.erb
+++ b/app/views/reservations/_side_bar.html.erb
@@ -5,7 +5,7 @@
           edit_customer_registration_path(current_customer), method: :get, class: "customer-name" %>
     <% end %>
   </div>
-  <div class="log-out">
+  <div class="sign-out">
     <% if customer_signed_in? %>
     <%= link_to "Sign Out", destroy_customer_session_path, method: :delete %>
     <% end %>

--- a/app/views/reservations/_side_bar.html.erb
+++ b/app/views/reservations/_side_bar.html.erb
@@ -1,10 +1,14 @@
 <div class="side-bar-header">
   <div class="header-name">
+    <% if customer_signed_in? %>
     <%= link_to current_customer.last_name + ' ' + current_customer.first_name + ' 様',
           edit_customer_registration_path(current_customer), method: :get, class: "customer-name" %>
+    <% end %>
   </div>
   <div class="log-out">
+    <% if customer_signed_in? %>
     <%= link_to "Sign Out", destroy_customer_session_path, method: :delete %>
+    <% end %>
   </div>
 </div>
 <div class="staffs">

--- a/app/views/reservations/edit.html.erb
+++ b/app/views/reservations/edit.html.erb
@@ -1,14 +1,29 @@
-<div class='reservation-page' id='reservation-page'>
-  <div class='reservation-page__inner clearfix'>
-    <div class='reservation-page__inner--left reservation-page__header'>
-      <h2>Edit Reservation</h2>
-      <h5>予約の変更</h5>
+<div class="wrapper">
+  <div class="side-bar">
+    <%= render "side_bar" %>
+  </div>
+  <div class="reservation-main">
+    <%= form_with model: @reservation, url: reservation_path, method: :patch, local: true do |f|%>
+    <div class="reservation-main-header">
+      <div class="left-header">
+        <div class="header-title">
+          ご予約の変更
+        </div>
+      </div>
+      <div class="right-header">
+        <div class="header-button-parent">
+          <div class="header-button-reverse">
+            <%= link_to "Back Page", reservation_path %>
+          </div>
+          <div class="actions">
+            <%= f.submit "Update Reservation", class: 'btn', data: { confirm: 'Are you sure you want to change it?' } %>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class='reservation-page__inner--right user-form'>
-      <%= form_with model: @reservation, url: reservation_path, method: :patch, local: true do |f|%>
-
+    <div class="reservation-parent">
+      <div class="reservation">
       <%= render 'shared/error_messages', model: @reservation %>
-
         <div class='field'>
           <div class="field-label">
             <b>予約日時</b>
@@ -19,9 +34,10 @@
                         with_css_classes:'select-start-time',
                         id:"start-time",
                         use_month_numbers: true,
+                        default: (DateTime.now) + 1.0.hour,
                         start_year: (DateTime.now.year),
                         end_year: (DateTime.now.year + 1),
-                        start_hour: 8,
+                        start_hour: 10,
                         end_hour: 17,
                         minute_step: 30,
                         date_separator: '%s'),
@@ -39,13 +55,8 @@
           </div>
           <%= f.collection_select(:menu_id, Menu.all, :id, :name, {}, {class:"select-box", id:"reservation-menu"}) %>
         </div>
-        <div class='actions'>
-          <%= f.submit "Update Reservation", class: 'btn'%>
-        </div>
-        <div class='actions'>
-          <%= link_to 'Back', reservation_path, class: 'back-btn' %>
-        </div>
       </div>
     <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -22,7 +22,7 @@
                         default: (DateTime.now) + 1.0.hour,
                         start_year: (DateTime.now.year),
                         end_year: (DateTime.now.year + 1),
-                        start_hour: 8,
+                        start_hour: 10,
                         end_hour: 17,
                         minute_step: 30,
                         date_separator: '%s'),

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -1,14 +1,29 @@
-<div class='reservation-page' id='reservation-page'>
-  <div class='reservation-page__inner clearfix'>
-    <div class='reservation-page__inner--left reservation-page__header'>
-      <h2>New Reservation</h2>
-      <h5>新規予約</h5>
+<div class="wrapper">
+  <div class="side-bar">
+    <%= render "side_bar" %>
+  </div>
+  <div class="reservation-main">
+    <%= form_with model: @reservation, url: reservations_path, local: true do |f|%>
+    <div class="reservation-main-header">
+      <div class="left-header">
+        <div class="header-title">
+          新規ご予約
+        </div>
+      </div>
+      <div class="right-header">
+        <div class="header-button-parent">
+          <div class="header-button-reverse">
+            <%= link_to "Index Page", staffs_path %>
+          </div>
+          <div class="actions">
+            <%= f.submit "Create Reservation", class: 'btn' %>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class='reservation-page__inner--right user-form'>
-      <%= form_with model: @reservation, url: reservations_path, local: true do |f|%>
-
+    <div class="reservation-parent">
+      <div class="reservation">
       <%= render 'shared/error_messages', model: @reservation %>
-
         <div class='field'>
           <div class="field-label">
             <b>予約日時</b>
@@ -40,13 +55,8 @@
           </div>
           <%= f.collection_select(:menu_id, Menu.all, :id, :name, {}, {class:"select-box", id:"reservation-menu"}) %>
         </div>
-        <div class='actions'>
-          <%= f.submit "Create Reservation", class: 'btn'%>
-        </div>
-        <div class='actions'>
-          <%= link_to 'Back', root_path, class: 'back-btn' %>
-        </div>
       </div>
     <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -12,13 +12,13 @@
       <div class="right-header">
         <div class="header-button-parent">
           <div class="header-button-reverse">
-            <%= link_to "Destroy Reservation", reservation_path(@reservation.id), method: :delete ,data: { confirm: 'Are you sure you want to cancel?' } %>
+            <%= link_to "Destroy Reservation", reservation_path(@reservation.id), method: :delete, data: { confirm: 'Are you sure you want to cancel?' } %>
           </div>
           <div class="header-button-reverse">
             <%= link_to "To Edit Reservation", edit_reservation_path(@reservation.id) %>
           </div>
           <div class="header-button">
-            <%= link_to "Back Page", :back %>
+            <%= link_to "Index Page", staffs_path %>
           </div>
         </div>
       </div>

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -11,7 +11,7 @@
       </div>
       <div class="right-header">
         <div class="header-button-parent">
-          <div class="header-button-destroy">
+          <div class="header-button-reverse">
             <%= link_to "Destroy Reservation", reservation_path(@reservation.id), method: :delete ,data: { confirm: 'Are you sure you want to cancel?' } %>
           </div>
           <div class="header-button">

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -14,8 +14,11 @@
           <div class="header-button-reverse">
             <%= link_to "Destroy Reservation", reservation_path(@reservation.id), method: :delete ,data: { confirm: 'Are you sure you want to cancel?' } %>
           </div>
+          <div class="header-button-reverse">
+            <%= link_to "To Edit Reservation", edit_reservation_path(@reservation.id) %>
+          </div>
           <div class="header-button">
-            <%= link_to "Edit Reservation", edit_reservation_path(@reservation.id), method: :get,data: { confirm: 'Do you need to change it?' } %>
+            <%= link_to "Back Page", :back %>
           </div>
         </div>
       </div>
@@ -23,6 +26,8 @@
     <div class="show-table-parent">
       <table class="show-table">
         <tr> <th>お客様名</th> <td><%= @reservation.customer.last_name + ' ' + @reservation.customer.first_name + ' 様' %></td> </tr>
+        <tr> <th>お客様名(カナ)</th> <td><%= @reservation.customer.last_name_kana + ' ' + @reservation.customer.first_name_kana + ' サマ' %></td> </tr>
+        <tr> <th>お電話番号</th> <td><%= @reservation.customer.phone_number %></td> </tr>
         <tr> <th>ご予約日時</th>
           <td>
             <%= @reservation.start_time.strftime('%Y/%m/%d') + '(' + %w(日 月 火 水 木 金 土)[@reservation.start_time.wday] + ')' %>

--- a/app/views/staffs/_main.html.erb
+++ b/app/views/staffs/_main.html.erb
@@ -1,12 +1,26 @@
 <div class="reservation-main-header">
   <div class="left-header">
     <div class="header-title">
-      <%= 'ご予約の状況：すべて' %>
+      ご予約の状況：すべて
     </div>
   </div>
   <div class="right-header">
-    <div class="header-button">
-      <%= link_to "New Reservation", new_reservation_path, method: :get %>
+    <div class="header-button-parent">
+      <div class="header-button-reverse">
+        <%= link_to "Top Page", root_path, method: :get %>
+      </div>
+      <% if customer_signed_in? %>
+      <div class="header-button">
+        <%= link_to "To New Reservation", new_reservation_path, method: :get %>
+      </div>
+      <% else %>
+      <div class="header-button-reverse">
+        <%= link_to "To Sign Up", new_customer_registration_path, method: :get %>
+      </div>
+      <div class="header-button">
+        <%= link_to "To Sign In", new_customer_session_path, method: :get %>
+      </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/staffs/_main.html.erb
+++ b/app/views/staffs/_main.html.erb
@@ -1,7 +1,7 @@
 <div class="reservation-main-header">
   <div class="left-header">
     <div class="header-title">
-      <%= 'ご予約の状況(担当別)：' + @staff.name %>
+      <%= 'ご予約の状況：すべて' %>
     </div>
   </div>
   <div class="right-header">
@@ -15,7 +15,7 @@
 <div class="reservations">
   <table class="index-table">
     <tr>
-      <th>日付</th> <th>開始時刻</th> <th>終了時刻</th> <th>お客様名</th> <th>メニュー</th> <th>最終更新日時</th>
+      <th>日付</th> <th>開始時刻</th> <th>終了時刻</th> <th>お客様名</th> <th>メニュー</th> <th>担当</th> <th>最終更新日時</th>
     </tr>
   <%= render partial: 'reservation', collection: @reservations %>
   <table>
@@ -23,7 +23,7 @@
 <% else%>
 <div class="reservations-none">
   <div class="reservation-none">
-  <%= @staff.name + 'の予約情報はありません。ご予約をお待ちしております。'%>
+  <%= '予約情報はありません。ご予約をお待ちしております。' %>
   </div>
 </div>
 <% end %>

--- a/app/views/staffs/_reservation.html.erb
+++ b/app/views/staffs/_reservation.html.erb
@@ -1,5 +1,5 @@
 <div class="reservation">
-  <% if current_customer.id == reservation.customer.id %>
+  <% if customer_signed_in? && current_customer.id == reservation.customer.id %>
   <tr>
     <td><%= link_to reservation.start_time.strftime('%Y/%m/%d') + '(' + %w(日 月 火 水 木 金 土)[reservation.start_time.wday] + ')', reservation_path(reservation.id) %></td>
     <td><%= link_to reservation.start_time.strftime('%H:%M'), reservation_path(reservation.id) %></td>

--- a/app/views/staffs/_reservation.html.erb
+++ b/app/views/staffs/_reservation.html.erb
@@ -1,0 +1,29 @@
+<div class="reservation">
+  <% if current_customer.id == reservation.customer.id %>
+  <tr>
+    <td><%= link_to reservation.start_time.strftime('%Y/%m/%d') + '(' + %w(日 月 火 水 木 金 土)[reservation.start_time.wday] + ')', reservation_path(reservation.id) %></td>
+    <td><%= link_to reservation.start_time.strftime('%H:%M'), reservation_path(reservation.id) %></td>
+    <td><%= link_to reservation.end_time.strftime('%H:%M'), reservation_path(reservation.id) %></td>
+    <td class="text-left" ><%= link_to reservation.customer.last_name + ' ' + reservation.customer.first_name + ' 様', reservation_path(reservation.id) %></td>
+    <td class="text-left" ><%= link_to reservation.menu.name, reservation_path(reservation.id) %></td>
+    <td class="text-left" ><%= link_to reservation.staff.name, reservation_path(reservation.id) %></td>
+    <td>
+      <%= link_to reservation.updated_at.strftime('%Y/%m/%d') + '(' + %w(日 月 火 水 木 金 土)[reservation.updated_at.wday] + ') ' +
+          reservation.updated_at.strftime('%H:%M'), reservation_path(reservation.id) %>
+    </td>
+  </tr>
+  <% else%>
+  <tr>
+    <td><%= reservation.start_time.strftime('%Y/%m/%d') + '(' + %w(日 月 火 水 木 金 土)[reservation.start_time.wday] + ')' %></td>
+    <td><%= reservation.start_time.strftime('%H:%M') %></td>
+    <td><%= reservation.end_time.strftime('%H:%M') %></td>
+    <td class="text-left" >他のお客様がご予約済み</td>
+    <td class="text-left" ><%= reservation.menu.name %></td>
+    <td class="text-left" ><%= reservation.staff.name %></td>
+    <td>
+      <%= reservation.updated_at.strftime('%Y/%m/%d') + '(' + %w(日 月 火 水 木 金 土)[reservation.updated_at.wday] + ') ' +
+          reservation.updated_at.strftime('%H:%M') %>
+    </td>
+  </tr>
+  <% end %>
+</div>

--- a/app/views/staffs/index.html.erb
+++ b/app/views/staffs/index.html.erb
@@ -3,29 +3,6 @@
     <%= render "reservations/side_bar" %>
   </div>
   <div class="reservation-main">
-    <div class="reservation-main-header">
-      <div class="left-header">
-        <div class="header-title">
-          <b>Welcome to "Original App 32479 Beauty Salon"</b>
-        </div>
-      </div>
-      <div class="right-header">
-      </div>
-    </div>
-    <div class="top-page">
-      <%= image_tag 'building_biyouin.png', size: "360x360", class: "top-img-file" %>
-      <div class="title">
-        オリジナルアプリ32479美容室へようこそ
-      </div>
-      <div class="text">
-        (営業時間) 08:00 から 18:00 まで  (定休日) 毎週火曜日
-      </div>
-      <div class="message">
-        左側の担当者をクリックするとご予約いただけます
-      </div>
-      <div class="copy-right">
-        (c) 2021 Original App 32479 Beauty Salon. All rights reserved. 
-      </div>
-    </div>
+    <%= render "main" %>
   </div>
-</div></div>
+</div>

--- a/app/views/staffs/index.html_back.erb
+++ b/app/views/staffs/index.html_back.erb
@@ -1,0 +1,31 @@
+<div class="wrapper">
+  <div class="side-bar">
+    <%= render "reservations/side_bar" %>
+  </div>
+  <div class="reservation-main">
+    <div class="reservation-main-header">
+      <div class="left-header">
+        <div class="header-title">
+          <b>Welcome to "Original App 32479 Beauty Salon"</b>
+        </div>
+      </div>
+      <div class="right-header">
+      </div>
+    </div>
+    <div class="top-page">
+      <%= image_tag 'building_biyouin.png', size: "360x360", class: "top-img-file" %>
+      <div class="title">
+        オリジナルアプリ32479美容室へようこそ
+      </div>
+      <div class="text">
+        (営業時間) 10:00 から 18:00 まで  (定休日) 毎週火曜日
+      </div>
+      <div class="message">
+        左側の担当者をクリックするとご予約いただけます
+      </div>
+      <div class="copy-right">
+        (c) 2021 Original App 32479 Beauty Salon. All rights reserved. 
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -15,10 +15,13 @@
           <div class="header-button-reverse">
             <%= link_to "To Sign Up", new_customer_registration_path, method: :get %>
           </div>
-          <div class="header-button">
+          <div class="header-button-reverse">
             <%= link_to "To Sign In", new_customer_session_path, method: :get %>
           </div>
           <% end %>
+          <div class="header-button">
+            <%= link_to "Index Page", staffs_path, method: :get %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -10,6 +10,16 @@
         </div>
       </div>
       <div class="right-header">
+        <div class="header-button-parent">
+          <% unless customer_signed_in? %>
+          <div class="header-button-reverse">
+            <%= link_to "To Sign Up", new_customer_registration_path, method: :get %>
+          </div>
+          <div class="header-button">
+            <%= link_to "To Sign In", new_customer_session_path, method: :get %>
+          </div>
+          <% end %>
+        </div>
       </div>
     </div>
     <div class="top-page">
@@ -21,7 +31,7 @@
         (営業時間) 10:00 から 18:00 まで  (定休日) 毎週火曜日
       </div>
       <div class="message">
-        左側の担当者をクリックするとご予約いただけます
+        予約の状況は左側のボタンをクリックするとご確認いただけます
       </div>
       <div class="copy-right">
         (c) 2021 Original App 32479 Beauty Salon. All rights reserved. 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,8 @@ Rails.application.routes.draw do
     registrations: 'customers/registrations'
   }
   
-  get 'customers/index'
-  root to: "staffs#index"
+  # get 'top/index'
+  root to: "top#index"
   resources :reservations
   resources :staffs, only: [:index]
 end

--- a/spec/helpers/top_helper_spec.rb
+++ b/spec/helpers/top_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the TopHelper. For example:
+#
+# describe TopHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe TopHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/top_request_spec.rb
+++ b/spec/requests/top_request_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe "Tops", type: :request do
+
+  describe "GET /index" do
+    it "returns http success" do
+      get "/top/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/requests/top_request_spec.rb
+++ b/spec/requests/top_request_spec.rb
@@ -1,12 +1,10 @@
 require 'rails_helper'
 
-RSpec.describe "Tops", type: :request do
-
-  describe "GET /index" do
-    it "returns http success" do
-      get "/top/index"
+RSpec.describe 'Tops', type: :request do
+  describe 'GET /index' do
+    it 'returns http success' do
+      get '/top/index'
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/spec/views/top/index.html.erb_spec.rb
+++ b/spec/views/top/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "top/index.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/top/index.html.erb_spec.rb
+++ b/spec/views/top/index.html.erb_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "top/index.html.erb", type: :view do
+RSpec.describe 'top/index.html.erb', type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
# What
予約関連ページを改善・拡充

## 主な変更点
### 予約一覧ページの追加
- すべてのスタッフの予約一覧ページを追加
### トップページの移動
### 予約情報詳細ページの拡充
- お客様名(カナ)を追加
- 電話番号を追加
### 予約情報登録ページの拡充
- レイアウトを他の機能と同様になるように変更
### 予約情報編集ページの拡充
- レイアウトを他の機能と同様になるように変更

# Why
上記のように予約関連ページの改善・拡充が必要であったため